### PR TITLE
Refactor pod handler to list pods in kube-system namespace

### DIFF
--- a/internal/cmd/sgmap/pod/handler.go
+++ b/internal/cmd/sgmap/pod/handler.go
@@ -68,7 +68,7 @@ func (o *options) Run() error {
 		return fmt.Errorf("Failed to create Kubernetes clientset: %v", err)
 	}
 
-	pods, err := clientset.CoreV1().Pods("step").List(context.TODO(), metav1.ListOptions{})
+	pods, err := clientset.CoreV1().Pods("kube-system").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("Failed to list pods: %v", err)
 	}


### PR DESCRIPTION
This pull request includes a small but important change to the `internal/cmd/sgmap/pod/handler.go` file. The change modifies the namespace from which pods are listed in the Kubernetes clientset.

* [`internal/cmd/sgmap/pod/handler.go`](diffhunk://#diff-e8c911c9c7c5372598a498c7bd75cec76b984ee2fab1ed5fafbfe55e8675ae12L71-R71): Changed the namespace from `"step"` to `"kube-system"` in the `clientset.CoreV1().Pods().List` method.