### PR TITLE
feat: enhance release workflow to comment on PR with next version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,11 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - name: Debug information
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "New release published: ${{ steps.determine_release.outputs.new_release_published }}"
+          echo "New release version: ${{ steps.determine_release.outputs.new_release_version }}"
       - name: Comment on PR with next version
         if: github.event_name == 'pull_request' && steps.determine_release.outputs.new_release_published == 'true'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   determine_release:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' }}
     permissions:
       contents: write
     outputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,72 +1,50 @@
-name: release
+name: Release
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
-  determine_release:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' }}
-    permissions:
-      contents: write
-    outputs:
-      will_release: ${{ steps.determine_release.outputs.new_release_published }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-      - id: determine_release
-        uses: cycjimmy/semantic-release-action@266ea7eb8c90943aa9cddd3b0ed326d5e8784a26 # v4.2.0
-        with:
-          dry_run: true
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-      - name: Debug information
-        run: |
-          echo "Event name: ${{ github.event_name }}"
-          echo "New release published: ${{ steps.determine_release.outputs.new_release_published }}"
-          echo "New release version: ${{ steps.determine_release.outputs.new_release_version }}"
-      - name: Comment on PR with next version
-        if: github.event_name == 'pull_request' && steps.determine_release.outputs.new_release_published == 'true'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            const version = '${{ steps.determine_release.outputs.new_release_version }}';
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `📦 Next release version will be: **${version}**`
-            });
-
   release:
     runs-on: ubuntu-latest
+    # restricts the job to run only maintainers
+    if: github.actor == 'naka-gawa'
     permissions:
       contents: write
-    needs:
-      - determine_release
-    if: ${{ needs.determine_release.outputs.will_release }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: cycjimmy/semantic-release-action@266ea7eb8c90943aa9cddd3b0ed326d5e8784a26 # v4.2.0
+
+      - name: Create Release with semantic-release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@266ea7eb8c90943aa9cddd3b0ed326d5e8784a26 # v4.2.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+
+      - name: Set up Go
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version-file: go.mod
           cache: true
+
       - name: Run GoReleaser
+        if: steps.semantic.outputs.new_release_published == 'true'
         uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4.6.0
         with:
           distribution: goreleaser
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GORELEASER_CURRENT_TAG: ${{ steps.semantic.outputs.new_release_version }}
+
+      - name: Report Release Status
+        if: always()
+        run: |
+          if [ "${{ steps.semantic.outputs.new_release_published }}" == "true" ]; then
+            echo "✅ Successfully created release ${{ steps.semantic.outputs.new_release_version }}"
+          else
+            echo "❌ No new release was created. No release-worthy changes were found."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,14 @@ jobs:
   determine_release:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
     outputs:
       will_release: ${{ steps.determine_release.outputs.new_release_published }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
       - id: determine_release
         uses: cycjimmy/semantic-release-action@266ea7eb8c90943aa9cddd3b0ed326d5e8784a26 # v4.2.0
         with:
@@ -21,6 +25,19 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - name: Comment on PR with next version
+        if: github.event_name == 'pull_request' && steps.determine_release.outputs.new_release_published == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const version = '${{ steps.determine_release.outputs.new_release_version }}';
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `📦 Next release version will be: **${version}**`
+            });
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for the release process. The changes primarily focus on improving the automation and feedback mechanisms in the release pipeline.

Improvements to the release workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R13-R40): Added `permissions` to allow writing contents.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R13-R40): Configured `fetch-depth: 0` for the `actions/checkout` step to ensure the entire history is fetched.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R13-R40): Added a step to comment on the pull request with the next version if a new release is published.