### PR TITLE
refactor: rename and enhance AWS client methods for fetching security…

### DIFF
--- a/internal/usecase/pod.go
+++ b/internal/usecase/pod.go
@@ -49,7 +49,7 @@ func (o *PodOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to create aws client: %w", err)
 	}
 
-	result, err := awsClient.GetSecurityGroupsForPods(ctx, pods)
+	result, err := awsClient.FetchSecurityGroupsByPods(ctx, pods)
 	if err != nil {
 		return fmt.Errorf("failed to get security groups: %w", err)
 	}


### PR DESCRIPTION
This pull request includes several updates to the `pkg/aws/client.go` and `internal/usecase/pod.go` files to improve the clarity and functionality of the methods related to retrieving security groups for pods. The main changes involve renaming methods for better clarity and enhancing the documentation.

Improvements and renaming methods:

* [`pkg/aws/client.go`](diffhunk://#diff-39260fbf46ea076702be0085fc20b3897395b779af4dbaee85902ce0b95d725dL38-R52): Renamed `GetSecurityGroupsForPods` to `FetchSecurityGroupsByPods` and updated the method documentation to provide a more comprehensive description of its functionality.
* [`pkg/aws/client.go`](diffhunk://#diff-39260fbf46ea076702be0085fc20b3897395b779af4dbaee85902ce0b95d725dL73-R82): Renamed `findENIForPodIP` to `LookupENIByPodIP` and updated the method documentation to explain its purpose and behavior more clearly.
* [`pkg/aws/client.go`](diffhunk://#diff-39260fbf46ea076702be0085fc20b3897395b779af4dbaee85902ce0b95d725dL95-R109): Renamed `getSecurityGroupsForENI` to `FetchSecurityGroupsByENI` and updated the method documentation to detail the process and API calls involved.

Code updates:

* [`internal/usecase/pod.go`](diffhunk://#diff-6de47bde78046e45443827d1160c6c41716feb94c8d4b58efe998faeb240ab1fL52-R52): Updated the call from `GetSecurityGroupsForPods` to `FetchSecurityGroupsByPods` to reflect the renamed method.
* [`pkg/aws/client.go`](diffhunk://#diff-39260fbf46ea076702be0085fc20b3897395b779af4dbaee85902ce0b95d725dL57-R62): Updated the internal calls from `findENIForPodIP` to `LookupENIByPodIP` and from `getSecurityGroupsForENI` to `FetchSecurityGroupsByENI` within the `FetchSecurityGroupsByPods` method.