### PR TITLE
feat-SecurityGroups-BatchParallel

### DIFF
--- a/internal/usecase/pod.go
+++ b/internal/usecase/pod.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/naka-gawa/kubectl-sgmap/pkg/aws"
 	"github.com/naka-gawa/kubectl-sgmap/pkg/kubernetes"
-	"github.com/naka-gawa/kubectl-sgmap/pkg/utils"
+	"github.com/naka-gawa/kubectl-sgmap/pkg/output"
 )
 
 // PodOptions contains options for the pod command
@@ -59,5 +59,5 @@ func (o *PodOptions) Run(ctx context.Context) error {
 		return nil
 	}
 
-	return utils.OutputPodSecurityGroups(o.IOStreams.Out, result, o.OutputFormat)
+	return output.OutputPodSecurityGroups(o.IOStreams.Out, result, o.OutputFormat)
 }

--- a/internal/usecase/pod.go
+++ b/internal/usecase/pod.go
@@ -49,7 +49,7 @@ func (o *PodOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to create aws client: %w", err)
 	}
 
-	result, err := awsClient.GetSecurityGroupsForPods(ctx, pods)
+	result, err := awsClient.FetchSecurityGroupsByPods(ctx, pods)
 	if err != nil {
 		return fmt.Errorf("failed to get security groups: %w", err)
 	}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -1,4 +1,4 @@
-package utils
+package output
 
 import (
 	"encoding/json"

--- a/pkg/utils/batch.go
+++ b/pkg/utils/batch.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"context"
+	"sync"
+)
+
+// ProcessBatchFunc defines the function signature for processing a batch
+// T is input item type, R is output result type (map key: string)
+type ProcessBatchFunc[T any, R any] func(context.Context, []T) (map[string]R, error)
+
+// RunBatchParallel splits the input items into batches and runs the processing function in parallel.
+// It returns a merged map of all batch results or the first error encountered.
+func RunBatchParallel[T any, R any](
+	ctx context.Context,
+	items []T,
+	batchSize int,
+	maxParallel int,
+	process ProcessBatchFunc[T, R],
+) (map[string]R, error) {
+	batches := chunkSlice(items, batchSize)
+	type result struct {
+		data map[string]R
+		err  error
+	}
+
+	resultCh := make(chan result, len(batches))
+	sem := make(chan struct{}, maxParallel)
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for _, batch := range batches {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(b []T) {
+			defer func() {
+				wg.Done()
+				<-sem
+			}()
+
+			out, err := process(ctx, b)
+			resultCh <- result{data: out, err: err}
+			if err != nil {
+				cancel()
+			}
+		}(batch)
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	final := make(map[string]R)
+	var firstErr error
+	for res := range resultCh {
+		if res.err != nil && firstErr == nil {
+			firstErr = res.err
+			continue
+		}
+		for k, v := range res.data {
+			final[k] = v
+		}
+	}
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return final, nil
+}
+
+func chunkSlice[T any](items []T, size int) [][]T {
+	var chunks [][]T
+	for i := 0; i < len(items); i += size {
+		end := i + size
+		if end > len(items) {
+			end = len(items)
+		}
+		chunks = append(chunks, items[i:end])
+	}
+	return chunks
+}


### PR DESCRIPTION
This pull request includes significant refactoring and enhancements to the AWS client and related utilities in the `kubectl-sgmap` project. The changes focus on improving the efficiency and clarity of fetching security group information for pods, as well as reorganizing and renaming some utility functions for better modularity.

### Refactoring and Enhancements to AWS Client:

* [`pkg/aws/client.go`](diffhunk://#diff-39260fbf46ea076702be0085fc20b3897395b779af4dbaee85902ce0b95d725dL38-R217): Refactored the `FetchSecurityGroupsByPods` method to improve efficiency and clarity. This includes breaking down the logic into smaller helper functions (`filterRunningPodsWithIPs`, `fetchENIAndSGIDs`, `collectUniqueSGIDs`, `buildPodSecurityGroupInfo`, `GetENIsByPrivateIPs`, `GetSecurityGroupsParallel`) to streamline processing and enhance readability.

### Package Reorganization:

* [`internal/usecase/pod.go`](diffhunk://#diff-6de47bde78046e45443827d1160c6c41716feb94c8d4b58efe998faeb240ab1fL11-R11): Replaced the import of `utils` with `output` and updated the corresponding function call to reflect this change. This is part of the effort to better organize the code by separating output-related utilities from general utilities. [[1]](diffhunk://#diff-6de47bde78046e45443827d1160c6c41716feb94c8d4b58efe998faeb240ab1fL11-R11) [[2]](diffhunk://#diff-6de47bde78046e45443827d1160c6c41716feb94c8d4b58efe998faeb240ab1fL62-R62)
* [`pkg/output/output.go`](diffhunk://#diff-733a99febfc84d2c4838483880c8a7317bd1d75f5278057c07a84be923876818L1-R1): Renamed from `pkg/utils/output.go` to better reflect its purpose of handling output-related functionalities.

### New Utility for Batch Processing:

* [`pkg/utils/batch.go`](diffhunk://#diff-3c1fc080b0e6ec610caddebf88d1f1f99874d569a7d7551e5b31925390af6f58R1-R83): Added a new utility function `RunBatchParallel` to handle batch processing in parallel. This utility splits input items into batches and processes them concurrently, which is particularly useful for operations like fetching security groups in parallel.

### Import Adjustments:

* [`pkg/aws/client.go`](diffhunk://#diff-39260fbf46ea076702be0085fc20b3897395b779af4dbaee85902ce0b95d725dR11): Added import for `utils` to utilize the newly added batch processing utility.
