### PR TITLE
test: add-batch-test-code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ format:
 
 test:
 ifeq ($(TEST_VERBOSE), true)
-	go test -v ./... -count=1
+	go test -v ./... -race -count=1
 else
-	go test ./... -count=1
+	go test ./... -race -count=1
 endif
 
 $(PLUGIN_BIN): $(PLUGIN_DEPENDENCIES)

--- a/cmd/pod.go
+++ b/cmd/pod.go
@@ -29,8 +29,8 @@ func NewPodCommand(streams *genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "", "namespace of the pod")
-	cmd.Flags().StringVar(&o.OutputFormat, "output", "", "output format (json|yaml|table)")
-	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", false, "search pods in all namespaces")
+	cmd.Flags().StringVar(&o.OutputFormat, "output", "o", "output format (json|yaml|table)")
+	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", false, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 
 	return cmd
 }

--- a/cmd/pod.go
+++ b/cmd/pod.go
@@ -29,7 +29,7 @@ func NewPodCommand(streams *genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "", "namespace of the pod")
-	cmd.Flags().StringVar(&o.OutputFormat, "output", "o", "output format (json|yaml|table)")
+	cmd.Flags().StringVarP(&o.OutputFormat, "output", "o", "", "output format (json|yaml|table)")
 	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", false, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 
 	return cmd

--- a/pkg/utils/batch.go
+++ b/pkg/utils/batch.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"maps"
 	"sync"
 )
 
@@ -9,8 +10,26 @@ import (
 // T is input item type, R is output result type (map key: string)
 type ProcessBatchFunc[T any, R any] func(context.Context, []T) (map[string]R, error)
 
-// RunBatchParallel splits the input items into batches and runs the processing function in parallel.
-// It returns a merged map of all batch results or the first error encountered.
+// batchResult represents the result of a single batch
+type batchResult[R any] struct {
+	data map[string]R
+	err  error
+}
+
+// RunBatchParallel splits items into batches and processes them concurrently.
+//
+// Arguments:
+//
+//	ctx         - Context for cancellation
+//	items       - Input items
+//	batchSize   - Size of each batch
+//	maxParallel - Maximum number of parallel workers
+//	process     - Processing function
+//
+// Returns:
+//
+//	A map with string keys representing merged batch results.
+//	Returns an error if any batch fails.
 func RunBatchParallel[T any, R any](
 	ctx context.Context,
 	items []T,
@@ -18,32 +37,25 @@ func RunBatchParallel[T any, R any](
 	maxParallel int,
 	process ProcessBatchFunc[T, R],
 ) (map[string]R, error) {
-	batches := chunkSlice(items, batchSize)
-	type result struct {
-		data map[string]R
-		err  error
-	}
-
-	resultCh := make(chan result, len(batches))
-	sem := make(chan struct{}, maxParallel)
-	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	batches := chunkSlice(items, batchSize)
+	resultCh := make(chan batchResult[R], len(batches))
+
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, maxParallel)
 
 	for _, batch := range batches {
 		wg.Add(1)
 		sem <- struct{}{}
+
 		go func(b []T) {
 			defer func() {
 				wg.Done()
 				<-sem
 			}()
-
-			out, err := process(ctx, b)
-			resultCh <- result{data: out, err: err}
-			if err != nil {
-				cancel()
-			}
+			runBatch(ctx, b, process, resultCh, cancel)
 		}(batch)
 	}
 
@@ -52,16 +64,43 @@ func RunBatchParallel[T any, R any](
 		close(resultCh)
 	}()
 
+	return collectResults(resultCh)
+}
+
+// runBatch processes a single batch and sends the result to the channel
+//
+// Arguments:
+//
+//	ctx: Context for cancellation
+//	batch: Batch of items
+//	process: Processing function
+//	resultCh: Channel for results
+//	cancel: Cancellation function
+func runBatch[T any, R any](
+	ctx context.Context,
+	batch []T,
+	process ProcessBatchFunc[T, R],
+	resultCh chan<- batchResult[R],
+	cancel context.CancelFunc,
+) {
+	res, err := process(ctx, batch)
+	if err != nil {
+		cancel()
+	}
+	resultCh <- batchResult[R]{data: res, err: err}
+}
+
+// collectResults collects results from the channel and merges them into a single map
+func collectResults[R any](results <-chan batchResult[R]) (map[string]R, error) {
 	final := make(map[string]R)
 	var firstErr error
-	for res := range resultCh {
+
+	for res := range results {
 		if res.err != nil && firstErr == nil {
 			firstErr = res.err
 			continue
 		}
-		for k, v := range res.data {
-			final[k] = v
-		}
+		maps.Copy(final, res.data)
 	}
 
 	if firstErr != nil {
@@ -70,13 +109,11 @@ func RunBatchParallel[T any, R any](
 	return final, nil
 }
 
+// chunkSlice splits a slice into chunks of the given size
 func chunkSlice[T any](items []T, size int) [][]T {
 	var chunks [][]T
 	for i := 0; i < len(items); i += size {
-		end := i + size
-		if end > len(items) {
-			end = len(items)
-		}
+		end := min(i+size, len(items))
 		chunks = append(chunks, items[i:end])
 	}
 	return chunks

--- a/pkg/utils/batch_test.go
+++ b/pkg/utils/batch_test.go
@@ -1,0 +1,89 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestRunBatchParallel(t *testing.T) {
+	type testCase struct {
+		name        string
+		items       []string
+		batchSize   int
+		maxParallel int
+		process     ProcessBatchFunc[string, string]
+		wantErr     bool
+		expectKeys  []string
+	}
+
+	tests := []testCase{
+		{
+			name:        "all batches succeed",
+			items:       []string{"192.168.0.1", "192.168.0.2"},
+			batchSize:   2,
+			maxParallel: 2,
+			process:     makeProcessWithErrorIP(""),
+			wantErr:     false,
+			expectKeys:  []string{"192.168.0.1", "192.168.0.2"},
+		},
+		{
+			name:        "first batch fails",
+			items:       []string{"192.168.0.1", "192.168.0.2"},
+			batchSize:   2,
+			maxParallel: 2,
+			process:     makeProcessWithErrorIP("192.168.0.1"),
+			wantErr:     true,
+			expectKeys:  nil,
+		},
+		{
+			name:        "context canceled before second batch",
+			items:       []string{"192.168.0.1", "192.168.0.2"},
+			batchSize:   2,
+			maxParallel: 1,
+			process:     makeProcessWithErrorIP("192.168.0.1"),
+			wantErr:     true,
+			expectKeys:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			got, err := RunBatchParallel(ctx, tt.items, tt.batchSize, tt.maxParallel, tt.process)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("expected error: %v, got: %v", tt.wantErr, err)
+			}
+
+			if !tt.wantErr {
+				var gotKeys []string
+				for k := range got {
+					gotKeys = append(gotKeys, k)
+				}
+				sort.Strings(gotKeys)
+				sort.Strings(tt.expectKeys)
+				if !reflect.DeepEqual(gotKeys, tt.expectKeys) {
+					t.Errorf("expected keys %v, but got %v (case: %s)", tt.expectKeys, gotKeys, tt.name)
+				}
+			}
+		})
+	}
+}
+
+func makeProcessWithErrorIP(errorIp string) ProcessBatchFunc[string, string] {
+	return func(ctx context.Context, batch []string) (map[string]string, error) {
+		for _, ip := range batch {
+			if ip == errorIp {
+				return nil, errors.New("error from first batch")
+			}
+		}
+		res := make(map[string]string)
+		for _, v := range batch {
+			res[v] = "ok"
+		}
+		return res, nil
+	}
+}


### PR DESCRIPTION
This pull request includes several significant changes to improve the test process, update flag definitions, and enhance the batch processing functionality. The most important changes are summarized below:

### Test Process Improvements:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L18-R20): Added the `-race` flag to the `go test` command to enable race condition detection during testing.

### Flag Definitions Update:
* [`cmd/pod.go`](diffhunk://#diff-fee3f52ce83f312d047f339429f8503a2e406349128fa52c98580c963ea65ee6L32-R33): Updated the definition of the `output` flag to include a shorthand `-o` and improved the description of the `all-namespaces` flag.

### Batch Processing Enhancements:
* [`pkg/utils/batch.go`](diffhunk://#diff-3c1fc080b0e6ec610caddebf88d1f1f99874d569a7d7551e5b31925390af6f58R5-R58): Refactored the `RunBatchParallel` function to improve readability and maintainability by introducing `batchResult` struct, `runBatch`, and `collectResults` helper functions. [[1]](diffhunk://#diff-3c1fc080b0e6ec610caddebf88d1f1f99874d569a7d7551e5b31925390af6f58R5-R58) [[2]](diffhunk://#diff-3c1fc080b0e6ec610caddebf88d1f1f99874d569a7d7551e5b31925390af6f58R67-R103) [[3]](diffhunk://#diff-3c1fc080b0e6ec610caddebf88d1f1f99874d569a7d7551e5b31925390af6f58R112-R116)
* [`pkg/utils/batch.go`](diffhunk://#diff-3c1fc080b0e6ec610caddebf88d1f1f99874d569a7d7551e5b31925390af6f58R5-R58): Added the `maps` package to use the `maps.Copy` function for merging batch results.

### Test Coverage:
* [`pkg/utils/batch_test.go`](diffhunk://#diff-7d4f8c5901a1cda01b068b1f3e03d2d8a08ef56d94abea58b9c3bb0b87d05d28R1-R89): Added unit tests for the `RunBatchParallel` function to ensure its correctness and handle different scenarios, including successful batch processing, batch failures, and context cancellation.