### PR TITLE
feat: implement dependency injection for Kubernetes and AWS clients

### DIFF
--- a/internal/usecase/pod_test.go
+++ b/internal/usecase/pod_test.go
@@ -1,0 +1,311 @@
+package usecase
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	awsSDK "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/naka-gawa/kubectl-sgmap/pkg/aws"
+	"github.com/naka-gawa/kubectl-sgmap/pkg/kubernetes"
+)
+
+type fakeK8sClient struct {
+	GetPodsFunc func(ctx context.Context, namespace, podName string, allNamespaces bool) ([]corev1.Pod, error)
+}
+
+type fakeAWSClient struct {
+	FetchSecurityGroupsByPodsFunc func(ctx context.Context, pods []corev1.Pod) ([]aws.PodSecurityGroupInfo, error)
+}
+
+func (f *fakeK8sClient) GetPods(ctx context.Context, namespace, podName string, allNamespaces bool) ([]corev1.Pod, error) {
+	return f.GetPodsFunc(ctx, namespace, podName, allNamespaces)
+}
+
+func (f *fakeAWSClient) FetchSecurityGroupsByPods(ctx context.Context, pods []corev1.Pod) ([]aws.PodSecurityGroupInfo, error) {
+	return f.FetchSecurityGroupsByPodsFunc(ctx, pods)
+}
+
+func runPodOptionsTest(t *testing.T, o *PodOptions, wantErr bool, checkOutput func(*testing.T, string)) {
+	t.Helper()
+
+	err := o.Run(context.Background())
+	if wantErr {
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+		return
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	got := o.IOStreams.Out.(*bytes.Buffer).String()
+
+	if checkOutput != nil {
+		checkOutput(t, got)
+	}
+}
+
+func TestPodOptions_Run(t *testing.T) {
+	test := []struct {
+		name         string
+		kc           *fakeK8sClient
+		ac           *fakeAWSClient
+		gotOutput    *bytes.Buffer
+		outputFormat string
+		checkOutput  func(t *testing.T, output string)
+		wantErr      bool
+	}{
+		{
+			name: "no pods found",
+			kc: &fakeK8sClient{
+				GetPodsFunc: func(ctx context.Context, ns, name string, all bool) ([]corev1.Pod, error) {
+					return []corev1.Pod{}, nil
+				},
+			},
+			ac: &fakeAWSClient{
+				FetchSecurityGroupsByPodsFunc: func(ctx context.Context, pods []corev1.Pod) ([]aws.PodSecurityGroupInfo, error) {
+					return nil, nil
+				},
+			},
+			gotOutput: &bytes.Buffer{},
+			checkOutput: func(t *testing.T, output string) {
+				t.Helper()
+				expected := "No resources found in namespace.\n"
+				if output != expected {
+					t.Errorf("expected output %q, but got %q", expected, output)
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name:         "json output",
+			outputFormat: "json",
+			kc: &fakeK8sClient{
+				GetPodsFunc: func(ctx context.Context, ns, name string, all bool) ([]corev1.Pod, error) {
+					return []corev1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-pod",
+								Namespace: "default",
+							},
+							Status: corev1.PodStatus{
+								PodIP: "10.0.0.1",
+								Phase: corev1.PodRunning,
+							},
+						},
+					}, nil
+				},
+			},
+			ac: &fakeAWSClient{
+				FetchSecurityGroupsByPodsFunc: func(ctx context.Context, pods []corev1.Pod) ([]aws.PodSecurityGroupInfo, error) {
+					return []aws.PodSecurityGroupInfo{
+						{
+							Pod: pods[0],
+							ENI: "eni-1234",
+							SecurityGroups: []types.SecurityGroup{
+								{
+									GroupId:   awsSDK.String("sg-1234"),
+									GroupName: awsSDK.String("test-sg"),
+								},
+							},
+						},
+					}, nil
+				},
+			},
+			gotOutput: &bytes.Buffer{},
+			checkOutput: func(t *testing.T, output string) {
+				t.Helper()
+				if !strings.Contains(output, `"eni-1234"`) ||
+					!strings.Contains(output, `"sg-1234"`) ||
+					!strings.Contains(output, `"test-sg"`) {
+					t.Errorf("unexpected json output: %s", output)
+				}
+			},
+		},
+		{
+			name:         "yaml output",
+			outputFormat: "yaml",
+			kc: &fakeK8sClient{
+				GetPodsFunc: func(ctx context.Context, ns, name string, all bool) ([]corev1.Pod, error) {
+					return []corev1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-pod",
+								Namespace: "default",
+							},
+							Status: corev1.PodStatus{
+								PodIP: "10.0.0.1",
+								Phase: corev1.PodRunning,
+							},
+						},
+					}, nil
+				},
+			},
+			ac: &fakeAWSClient{
+				FetchSecurityGroupsByPodsFunc: func(ctx context.Context, pods []corev1.Pod) ([]aws.PodSecurityGroupInfo, error) {
+					return []aws.PodSecurityGroupInfo{
+						{
+							Pod: pods[0],
+							ENI: "eni-1234",
+							SecurityGroups: []types.SecurityGroup{
+								{
+									GroupId:   awsSDK.String("sg-1234"),
+									GroupName: awsSDK.String("test-sg"),
+								},
+							},
+						},
+					}, nil
+				},
+			},
+			gotOutput: &bytes.Buffer{},
+			checkOutput: func(t *testing.T, output string) {
+				t.Helper()
+				if !strings.Contains(output, "eni: eni-1234") ||
+					!strings.Contains(output, "groupId: sg-1234") ||
+					!strings.Contains(output, "groupName: test-sg") {
+					t.Errorf("unexpected yaml output: %s", output)
+				}
+			},
+		},
+		{
+			name:         "structured data validation",
+			outputFormat: "json",
+			kc: &fakeK8sClient{
+				GetPodsFunc: func(ctx context.Context, ns, name string, all bool) ([]corev1.Pod, error) {
+					return []corev1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-pod",
+								Namespace: "default",
+							},
+							Status: corev1.PodStatus{
+								PodIP: "10.0.0.1",
+								Phase: corev1.PodRunning,
+							},
+						},
+					}, nil
+				},
+			},
+			ac: &fakeAWSClient{
+				FetchSecurityGroupsByPodsFunc: func(ctx context.Context, pods []corev1.Pod) ([]aws.PodSecurityGroupInfo, error) {
+					if len(pods) != 1 {
+						t.Errorf("expected 1 pod, got %d", len(pods))
+					}
+					pod := pods[0]
+					if pod.Name != "test-pod" || pod.Namespace != "default" || pod.Status.PodIP != "10.0.0.1" {
+						t.Errorf("unexpected pod info: %+v", pod)
+					}
+
+					return []aws.PodSecurityGroupInfo{
+						{
+							Pod: pod,
+							ENI: "eni-9999",
+							SecurityGroups: []types.SecurityGroup{
+								{
+									GroupId:   awsSDK.String("sg-9999"),
+									GroupName: awsSDK.String("zunda-sg"),
+								},
+							},
+						},
+					}, nil
+				},
+			},
+			gotOutput: &bytes.Buffer{},
+			checkOutput: func(t *testing.T, output string) {
+				t.Helper()
+				if output == "" {
+					return
+				}
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &PodOptions{
+				Namespace: "default",
+				IOStreams: &genericclioptions.IOStreams{
+					Out:    tt.gotOutput,
+					ErrOut: io.Discard,
+				},
+				OutputFormat: tt.outputFormat,
+				K8sClient:    tt.kc,
+				AWSClient:    tt.ac,
+			}
+			runPodOptionsTest(t, o, tt.wantErr, tt.checkOutput)
+		})
+	}
+}
+
+func TestPodOptions_K8sClientCreationError(t *testing.T) {
+	t.Helper()
+
+	original := newK8sClient
+	newK8sClient = func() (kubernetes.Interface, error) {
+		return nil, fmt.Errorf("mock k8s error")
+	}
+	defer func() { newK8sClient = original }()
+
+	o := &PodOptions{
+		Namespace: "default",
+		IOStreams: &genericclioptions.IOStreams{
+			Out:    &bytes.Buffer{},
+			ErrOut: io.Discard,
+		},
+		K8sClient: nil,
+		AWSClient: &fakeAWSClient{
+			FetchSecurityGroupsByPodsFunc: func(ctx context.Context, pods []corev1.Pod) ([]aws.PodSecurityGroupInfo, error) {
+				return nil, nil
+			},
+		},
+	}
+
+	err := o.Run(context.Background())
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "mock k8s error") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestPodOptions_AWSClientError(t *testing.T) {
+	o := &PodOptions{
+		Namespace: "default",
+		IOStreams: &genericclioptions.IOStreams{
+			Out:    &bytes.Buffer{},
+			ErrOut: io.Discard,
+		},
+		K8sClient: &fakeK8sClient{
+			GetPodsFunc: func(ctx context.Context, ns, name string, all bool) ([]corev1.Pod, error) {
+				return []corev1.Pod{
+					{Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.1"}},
+				}, nil
+			},
+		},
+		AWSClient: &fakeAWSClient{
+			FetchSecurityGroupsByPodsFunc: func(ctx context.Context, pods []corev1.Pod) ([]aws.PodSecurityGroupInfo, error) {
+				return nil, fmt.Errorf("mock AWS error")
+			},
+		},
+	}
+
+	err := o.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to get security groups: mock AWS error") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -15,6 +15,12 @@ type Client struct {
 	clientset *kubernetes.Clientset
 }
 
+// Interface defines the methods provided by the AWS EC2 client.
+// Used for dependency injection and testing.
+type Interface interface {
+	GetPods(ctx context.Context, namespace, podName string, allNamespaces bool) ([]corev1.Pod, error)
+}
+
 // NewClient creates a new Kubernetes client
 func NewClient() (*Client, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"text/tabwriter"
 
 	"gopkg.in/yaml.v2"
 
+	awsSDK "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/naka-gawa/kubectl-sgmap/pkg/aws"
 )
 
@@ -31,30 +33,65 @@ func outputJSON(w io.Writer, data interface{}) error {
 }
 
 // outputYAML outputs the data in YAML format
-func outputYAML(w io.Writer, data interface{}) error {
-	bytes, err := yaml.Marshal(data)
-	if err != nil {
-		return fmt.Errorf("failed to marshal to yaml: %w", err)
+func outputYAML(w io.Writer, data []aws.PodSecurityGroupInfo) error {
+	type sg struct {
+		GroupId   string `yaml:"groupId"`
+		GroupName string `yaml:"groupName"`
 	}
-	_, err = w.Write(bytes)
+
+	type out struct {
+		PodName        string `yaml:"podName"`
+		Namespace      string `yaml:"namespace"`
+		ENI            string `yaml:"eni"`
+		SecurityGroups []sg   `yaml:"securityGroups"`
+	}
+
+	var converted []out
+	for _, d := range data {
+		var groups []sg
+		for _, g := range d.SecurityGroups {
+			groups = append(groups, sg{
+				GroupId:   awsSDK.ToString(g.GroupId),
+				GroupName: awsSDK.ToString(g.GroupName),
+			})
+		}
+		converted = append(converted, out{
+			PodName:        d.Pod.Name,
+			Namespace:      d.Pod.Namespace,
+			ENI:            d.ENI,
+			SecurityGroups: groups,
+		})
+	}
+
+	b, err := yaml.Marshal(converted)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(w, string(b))
 	return err
 }
 
 // outputTable outputs the data in table format
-func outputTable(w io.Writer, data []aws.PodSecurityGroupInfo) error {
-	tabw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tabw, "NAMESPACE\tPOD\tENI\tSECURITY GROUP ID\tSECURITY GROUP NAME")
+func outputTable(w io.Writer, results []aws.PodSecurityGroupInfo) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAMESPACE\tPOD\tENI\tINTERFACE TYPE\tSECURITY GROUP ID\tSECURITY GROUP NAME")
 
-	for _, info := range data {
-		for _, sg := range info.SecurityGroups {
-			fmt.Fprintf(tabw, "%s\t%s\t%s\t%s\t%s\n",
-				info.Pod.Namespace,
-				info.Pod.Name,
-				info.ENI,
-				*sg.GroupId,
-				*sg.GroupName)
+	for _, r := range results {
+		var sgIDs []string
+		var sgNames []string
+		for _, sg := range r.SecurityGroups {
+			sgIDs = append(sgIDs, awsSDK.ToString(sg.GroupId))
+			sgNames = append(sgNames, awsSDK.ToString(sg.GroupName))
 		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			r.Pod.Name,
+			r.Pod.Namespace,
+			r.ENI,
+			r.InterfaceType,
+			strings.Join(sgIDs, ", "),
+			strings.Join(sgNames, ", "),
+		)
 	}
 
-	return tabw.Flush()
+	return tw.Flush()
 }


### PR DESCRIPTION
This pull request introduces several improvements and new features to the Kubernetes and AWS integration within the project. The most important changes include the addition of dependency injection for Kubernetes and AWS clients, enhanced error handling, and new test cases to ensure robustness.

### Dependency Injection and Client Initialization:
* [`internal/usecase/pod.go`](diffhunk://#diff-6de47bde78046e45443827d1160c6c41716feb94c8d4b58efe998faeb240ab1fR14-R26): Added `K8sClient` and `AWSClient` fields to `PodOptions` and modified the `Run` method to use these clients, allowing for easier testing and customization. [[1]](diffhunk://#diff-6de47bde78046e45443827d1160c6c41716feb94c8d4b58efe998faeb240ab1fR14-R26) [[2]](diffhunk://#diff-6de47bde78046e45443827d1160c6c41716feb94c8d4b58efe998faeb240ab1fL32-R64)

### Enhanced Testing:
* [`internal/usecase/pod_test.go`](diffhunk://#diff-3338f3a9ee7055e893b3df0c346f3fa9edf16c00904a99846243a4811c392a8aR1-R311): Introduced new test cases using fake clients to simulate different scenarios, such as no pods found, JSON and YAML output formats, and error handling for client creation.

### AWS Client Interface:
* [`pkg/aws/client.go`](diffhunk://#diff-39260fbf46ea076702be0085fc20b3897395b779af4dbaee85902ce0b95d725dR20-R31): Added an `Interface` type to define the methods provided by the AWS EC2 client, facilitating dependency injection and testing.
* Enhanced the `FetchSecurityGroupsByPods` method to include interface type information in the `PodSecurityGroupInfo` struct. [[1]](diffhunk://#diff-39260fbf46ea076702be0085fc20b3897395b779af4dbaee85902ce0b95d725dL46-R53) [[2]](diffhunk://#diff-39260fbf46ea076702be0085fc20b3897395b779af4dbaee85902ce0b95d725dL56-R63) [[3]](diffhunk://#diff-39260fbf46ea076702be0085fc20b3897395b779af4dbaee85902ce0b95d725dL118-R131) [[4]](diffhunk://#diff-39260fbf46ea076702be0085fc20b3897395b779af4dbaee85902ce0b95d725dR146-R154)

### Kubernetes Client Interface:
* [`pkg/kubernetes/client.go`](diffhunk://#diff-550f8c0b50fc78f89b2bf010a24381b9190b4f0fbee2a69aaa4397a52c328667R18-R23): Added an `Interface` type to define the methods provided by the Kubernetes client, facilitating dependency injection and testing.

### Output Formatting:
* [`pkg/output/output.go`](diffhunk://#diff-733a99febfc84d2c4838483880c8a7317bd1d75f5278057c07a84be923876818R7-R12): Updated the `outputYAML` and `outputTable` functions to include additional information, such as interface type, and improved the formatting of the output. [[1]](diffhunk://#diff-733a99febfc84d2c4838483880c8a7317bd1d75f5278057c07a84be923876818R7-R12) [[2]](diffhunk://#diff-733a99febfc84d2c4838483880c8a7317bd1d75f5278057c07a84be923876818L34-R96)

These changes collectively enhance the flexibility, testability, and functionality of the codebase, making it easier to maintain and extend in the future.