### PR TITLE
fix: output-header-namespace-and-pod

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -84,8 +84,8 @@ func outputTable(w io.Writer, results []aws.PodSecurityGroupInfo) error {
 			sgNames = append(sgNames, awsSDK.ToString(sg.GroupName))
 		}
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			r.Pod.Name,
 			r.Pod.Namespace,
+			r.Pod.Name,
 			r.ENI,
 			r.InterfaceType,
 			strings.Join(sgIDs, ", "),


### PR DESCRIPTION
This pull request includes a minor change to the `outputTable` function in the `pkg/output/output.go` file. The change adjusts the order of parameters in the `fmt.Fprintf` function call to ensure the pod name is printed correctly.

* [`pkg/output/output.go`](diffhunk://#diff-733a99febfc84d2c4838483880c8a7317bd1d75f5278057c07a84be923876818L87-R88): Adjusted the order of parameters in the `fmt.Fprintf` function call to correctly print the pod name.