### PR TITLE
CI: add sgmap plugin for visualizing security groups per pod

### DIFF
--- a/plugins/sgmap.yaml
+++ b/plugins/sgmap.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: sgmap
+spec:
+  version: "v0.7.0"
+  homepage: https://github.com/naka-gawa/kubectl-sgmap
+  shortDescription: "A kubectl plugin to visualize security group per pod."
+  description: |
+    A kubectl plugin to visualize security group per pod.
+    This plugin provides a command to generate a security group map for pods in a Kubernetes cluster.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/naka-gawa/kubectl-sgmap/releases/download/v0.7.0/kubectl-sgmap_Darwin_arm64.tar.gz
+      sha256: dca42b32e02de732deaabfc9379f7a4d33ee2de06b8708df5b854acae3996638
+      files:
+        - from: "kubectl-sgmap"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: "./kubectl-sgmap"


### PR DESCRIPTION
This pull request introduces a new plugin configuration for the `sgmap` tool in the `plugins/sgmap.yaml` file. The plugin is designed to visualize security groups per pod in a Kubernetes cluster.

### New plugin addition:

* [`plugins/sgmap.yaml`](diffhunk://#diff-dd4f0edf6921d4b73789850a55c0d22d9bd45cbdb1eaa0ed41d10a937276f00aR1-R25): Added a new plugin configuration for `sgmap` (version `v0.7.0`). This plugin provides a command to generate a security group map for pods in a Kubernetes cluster. It includes platform-specific details for Linux (amd64) and links to the plugin's binary and license file.