### PR TITLE
chore: update krew files

### DIFF
--- a/plugins/sgmap.yaml
+++ b/plugins/sgmap.yaml
@@ -16,7 +16,7 @@ spec:
           os: darwin
           arch: arm64
       uri: https://github.com/naka-gawa/kubectl-sgmap/releases/download/v0.7.2/kubectl-sgmap_Darwin_arm64.tar.gz
-      sha256: dca42b32e02de732deaabfc9379f7a4d33ee2de06b8708df5b854acae3996638
+      sha256: 86831a59253709f3264ca7e1a06e2990b4d2b38748f9828933fb7e28ac34312c
       files:
         - from: "kubectl-sgmap"
           to: "."


### PR DESCRIPTION
This pull request updates the SHA-256 checksum for the `kubectl-sgmap` plugin in the `plugins/sgmap.yaml` file to ensure the integrity of the downloaded file.

* [`plugins/sgmap.yaml`](diffhunk://#diff-dd4f0edf6921d4b73789850a55c0d22d9bd45cbdb1eaa0ed41d10a937276f00aL19-R19): Updated the `sha256` value for the `kubectl-sgmap` plugin on Darwin ARM64 from `dca42b32e02de732deaabfc9379f7a4d33ee2de06b8708df5b854acae3996638` to `86831a59253709f3264ca7e1a06e2990b4d2b38748f9828933fb7e28ac34312c`.