### PR TITLE
chore: update renovate.json to enhance automerge settings and add additional configuration options

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,14 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash",
+      "platformAutomerge": true
     }
-  ]
+  ],
+  "platformAutomerge": true,
+  "requiredStatusChecks": [],
+  "prCreation": "immediate",
+  "prHourlyLimit": 0
 }


### PR DESCRIPTION
This pull request updates the Renovate configuration to enhance and clarify the automerge process for dependency updates. The changes specify how automerges are performed, enable platform-level automerging, and adjust pull request creation settings.

**Renovate automerge and PR process improvements:**

* Set `automergeType` to `"pr"` and `automergeStrategy` to `"squash"` for minor and patch updates, ensuring that dependency updates are merged as squashed pull requests. (`renovate.json`)
* Enable `platformAutomerge` both globally and for the specific package rule, allowing the platform (e.g., GitHub) to handle the merge after checks pass. (`renovate.json`)
* Add `requiredStatusChecks` as an empty array, making it explicit that no status checks are required before automerging. (`renovate.json`)
* Set `prCreation` to `"immediate"` and remove the hourly PR limit (`prHourlyLimit: 0`), so Renovate creates pull requests as soon as updates are detected, without rate limiting. (`renovate.json`)