### PR TITLE
enable-automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
     {
       "matchCurrentVersion": "/^0/",
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": false
+      "automerge": true
     }
   ],
   "platformAutomerge": true


### PR DESCRIPTION
This pull request makes a small configuration change to the `renovate.json` file, enabling automatic merging for minor and patch updates of dependencies that match the specified version pattern.