### PR TITLE
update-renovate-json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,21 +7,15 @@
       "automerge": true
     },
     {
-      "matchDepTypes": ["devDependencies"],
-      "automerge": true
-    },
-    {
-      "matchPackageNames": [
-        "actions/checkout",
-        "actions/setup-go",
-        "dorny/paths-filter"
-      ],
-      "automerge": true
-    },
-    {
       "matchUpdateTypes": ["major"],
       "automerge": false
     }
   ],
-  "platformAutomerge": true
+  "platformAutomerge": true,
+  "automergeType": "pr",
+  "automergeComment": "Auto-approved Renovate PR",
+  "automergeLabel": "automerge",
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 2,
+  "prBodyNotes": ["**Automerge**: Enabled."]
 }


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to refine how Renovate automates dependency updates. The changes remove some previous automerge rules and introduce new settings to better control pull request automation and labeling.

**Renovate automation improvements:**

* Removed the automerge rules for `devDependencies` and specific GitHub Actions, consolidating automerge behavior.
* Added new configuration options: set `automergeType` to `"pr"`, added an `automergeComment`, and an `automergeLabel` to provide better context and tracking for automerged PRs.
* Introduced limits on Renovate PRs by setting `prConcurrentLimit` to 10 and `prHourlyLimit` to 2, helping to manage PR volume.
* Enhanced PR body notes with an explicit note when automerge is enabled.