### PR TITLE
update-renovate-json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
   "platformAutomerge": true,
   "automergeType": "pr",
   "automergeComment": "Auto-approved Renovate PR",
-  "automergeLabel": "automerge",
+  "labels": ["automerge"],
   "prConcurrentLimit": 10,
   "prHourlyLimit": 2,
   "prBodyNotes": ["**Automerge**: Enabled."]

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,5 @@
   "automergeComment": "Auto-approved Renovate PR",
   "labels": ["automerge"],
   "prConcurrentLimit": 10,
-  "prHourlyLimit": 2,
-  "prBodyNotes": ["**Automerge**: Enabled."]
+  "prHourlyLimit": 2
 }


### PR DESCRIPTION
- **fix: correct format of automerge label in renovate.json**
- **fix: remove redundant prBodyNotes from renovate.json**
