### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pull-requests: write
 name: Enable Auto-merge
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/naka-gawa/kubectl-sgmap/security/code-scanning/8](https://github.com/naka-gawa/kubectl-sgmap/security/code-scanning/8)

To fix the problem, add a `permissions` block to the workflow or the specific job to explicitly restrict the permissions of the `GITHUB_TOKEN`. The minimal required permission for most workflows is `contents: read`, but since this workflow also interacts with pull requests (approving and merging), it requires `pull-requests: write` in addition to `contents: read`. The best way to fix this is to add the following block at the top level of the workflow (just after the `name:` line), so it applies to all jobs unless overridden:

```yaml
permissions:
  contents: read
  pull-requests: write
```

This should be inserted after line 1, before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
