### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,6 +1,8 @@
 permissions:
   contents: read
 name: Pull Request
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/naka-gawa/kubectl-sgmap/security/code-scanning/5](https://github.com/naka-gawa/kubectl-sgmap/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the jobs in this workflow only need to read repository contents (for checkout and running tests), the most restrictive and appropriate setting is `contents: read`. This block should be added at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs unless overridden. No changes to the jobs themselves are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
