### PR TITLE
fix: update krew-release-bot version and add environment variables for GitHub token and reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Update new version in krew-index
         if: steps.semantic.outputs.new_release_published == 'true'
-        uses: rajatjindal/krew-release-bot@v0.0.47
+        uses: rajatjindal/krew-release-bot@3d9faef30a82761d610544f62afddca00993eef9 # v0.0.47
         env:
           GITHUB_REF: refs/tags/${{ steps.semantic.outputs.new_release_git_tag }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,11 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ steps.semantic.outputs.new_release_git_tag || steps.semantic.outputs.new_release_version }}
 
       - name: Update new version in krew-index
-        uses: rajatjindal/krew-release-bot@3d9faef30a82761d610544f62afddca00993eef9 # v0.0.47
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: rajatjindal/krew-release-bot@v0.0.47
+        env:
+          GITHUB_REF: refs/tags/${{ steps.semantic.outputs.new_release_git_tag }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Download release assets
         if: steps.semantic.outputs.new_release_published == 'true'


### PR DESCRIPTION
This pull request updates the release workflow to improve the krew-index update step by adding conditional execution and environment variables. The main change ensures that the krew-index update only runs when a new release is published and provides necessary environment variables for authentication and versioning.

Release workflow improvements:

* The krew-index update step now runs only if a new release is published, using the `if: steps.semantic.outputs.new_release_published == 'true'` condition. (`.github/workflows/release.yml`)
* The krew-index update step is updated to use the official `v0.0.47` tag and now includes environment variables `GITHUB_REF` and `GITHUB_TOKEN` for proper version and authentication handling. (`.github/workflows/release.yml`)