### PR TITLE
fix-krew-index-automation-workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     # restricts the job to run only maintainers
-    if: github.ref == 'refs/heads/main' && github.actor == 'naka-gawa'
+    if: github.actor == 'naka-gawa'
     permissions:
       contents: write
       pull-requests: write
@@ -18,8 +18,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+      - name: Generate GitHub App Token
         id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
@@ -29,16 +30,6 @@ jobs:
         uses: cycjimmy/semantic-release-action@9cc899c47e6841430bbaedb43de1560a568dfd16 # v5.0.0
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-
-      - name: Debug semantic-release output
-        run: |
-          echo "New release published: ${{ steps.semantic.outputs.new_release_published }}"
-          echo "New release version: ${{ steps.semantic.outputs.new_release_version }}"
-          echo "New release git tag: ${{ steps.semantic.outputs.new_release_git_tag }}"
-
-      - name: Fetch tags
-        if: steps.semantic.outputs.new_release_published == 'true'
-        run: git fetch --tags origin
 
       - name: Set up Go
         if: steps.semantic.outputs.new_release_published == 'true'
@@ -56,7 +47,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          GORELEASER_CURRENT_TAG: ${{ steps.semantic.outputs.new_release_git_tag || steps.semantic.outputs.new_release_version }}
+          GORELEASER_CURRENT_TAG: ${{ steps.semantic.outputs.new_release_git_tag }}
 
       - name: Update new version in krew-index
         if: steps.semantic.outputs.new_release_published == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Update new version in krew-index
         if: steps.semantic.outputs.new_release_published == 'true'
-        uses: rajatjindal/krew-release-bot@v0.0.47
+        uses: rajatjindal/krew-release-bot@3d9faef30a82761d610544f62afddca00993eef9 # v0.0.47
         env:
           GITHUB_REF: refs/tags/${{ steps.semantic.outputs.new_release_git_tag }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,11 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ steps.semantic.outputs.new_release_git_tag || steps.semantic.outputs.new_release_version }}
 
       - name: Update new version in krew-index
-        uses: rajatjindal/krew-release-bot@3d9faef30a82761d610544f62afddca00993eef9 # v0.0.47
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: rajatjindal/krew-release-bot@v0.0.47
+        env:
+          GITHUB_REF: refs/tags/${{ steps.semantic.outputs.new_release_git_tag }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Download release assets
         if: steps.semantic.outputs.new_release_published == 'true'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/release.yml` to improve release automation and ensure steps are only executed for published releases. The main changes focus on refining job conditions, improving step clarity, and ensuring environment variables are set consistently.

**Workflow logic and job condition improvements:**

* The release job now runs for any branch or tag pushed by the maintainer (`github.actor == 'naka-gawa'`), instead of restricting to the `main` branch only.

**Step and environment variable updates:**

* The step for generating a GitHub App token is now explicitly named `Generate GitHub App Token`, improving workflow readability.
* The environment variable `GORELEASER_CURRENT_TAG` is now set only to the new release git tag, removing fallback to the release version for clarity and correctness.

**Conditional execution and cleanup:**

* The `Update new version in krew-index` step now explicitly runs only if a new release is published, and sets required environment variables for that step.
* Unnecessary debug and tag-fetching steps have been removed to streamline the workflow and avoid redundant operations.
