### PR TITLE
feat: add krew.yaml configuration for kubectl-sgmap plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.actor == 'naka-gawa' || github.actor == 'kubectl-sgmap-action-apps[bot]'
     permissions:
       contents: write
     steps:
@@ -37,4 +38,4 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           GORELEASER_CURRENT_TAG: ${{ github.event.release.tag_name }}
       - name: Update new version in krew-index
-        uses: rajatjindal/krew-release-bot@df3eb197549e3568be8b4767eec31c5e8e8e6ad8 # v0.0.46
+        uses: rajatjindal/krew-release-bot@3d9faef30a82761d610544f62afddca00993eef9 # v0.0.47

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -25,7 +25,6 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      sha256: fea8adfa9f9ad8c264c055c02cafe3e894c0dc86f4816975eb29c0a6d223862e
       files:
         - from: "kubectl-sgmap"
           to: "."
@@ -37,7 +36,6 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      sha256: c8c793dbf244c2c90f46464263a37625192271cc2695b4a77f93b7c77143677e
       files:
         - from: "kubectl-sgmap"
           to: "."
@@ -49,7 +47,6 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      sha256: a1ce98a1d0ac0296fe7c6ae031e5d761b7f8809584491f46150a557ee4ae1313
       files:
         - from: "kubectl-sgmap"
           to: "."

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,59 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: sgmap
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/naka-gawa/kubectl-sgmap
+  shortDescription: "Visualize security group per pod."
+  description: |
+    A kubectl plugin to visualize security group per pod.
+    This plugin provides a command to generate a security group map for pods in a Kubernetes cluster.
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      files:
+        - from: "kubectl-sgmap"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: "./kubectl-sgmap"
+      {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Darwin_arm64.tar.gz" .TagName }}
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      sha256: fea8adfa9f9ad8c264c055c02cafe3e894c0dc86f4816975eb29c0a6d223862e
+      files:
+        - from: "kubectl-sgmap"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: "./kubectl-sgmap"
+      {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Darwin_x86_64.tar.gz" .TagName }}
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      sha256: c8c793dbf244c2c90f46464263a37625192271cc2695b4a77f93b7c77143677e
+      files:
+        - from: "kubectl-sgmap"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: "./kubectl-sgmap"
+      {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Linux_x86_64.tar.gz" .TagName }}
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      sha256: a1ce98a1d0ac0296fe7c6ae031e5d761b7f8809584491f46150a557ee4ae1313
+      files:
+        - from: "kubectl-sgmap"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: "./kubectl-sgmap"
+      {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Linux_arm64.tar.gz" .TagName }}


### PR DESCRIPTION
This pull request introduces support for distributing the `kubectl-sgmap` plugin via Krew and makes minor updates to the build workflow. The most significant changes are the addition of the Krew plugin manifest and an update to the release bot version, along with a conditional for triggering builds based on the GitHub actor.

**Krew plugin distribution:**

* Added a new `.krew.yaml` manifest to enable installation of `kubectl-sgmap` via Krew, specifying platform-specific binaries, metadata, and download links.

**Build workflow updates:**

* Updated the `krew-release-bot` action in `.github/workflows/build.yml` to use version `v0.0.47` for improved release automation.
* Added a conditional to the build workflow in `.github/workflows/build.yml` to restrict execution to specific GitHub actors (`naka-gawa` or `kubectl-sgmap-action-apps[bot]`).