### PR TITLE
fix: streamline platform configuration in krew.yaml

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -10,47 +10,47 @@ spec:
     A kubectl plugin to visualize security group per pod.
     This plugin provides a command to generate a security group map for pods in a Kubernetes cluster.
   platforms:
-    - selector:
-        matchLabels:
-          os: darwin
-          arch: arm64
-      files:
-        - from: "kubectl-sgmap"
-          to: "."
-        - from: "LICENSE"
-          to: "."
-      bin: "./kubectl-sgmap"
-      {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Darwin_arm64.tar.gz" .TagName }}
-    - selector:
-        matchLabels:
-          os: darwin
-          arch: amd64
-      files:
-        - from: "kubectl-sgmap"
-          to: "."
-        - from: "LICENSE"
-          to: "."
-      bin: "./kubectl-sgmap"
-      {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Darwin_x86_64.tar.gz" .TagName }}
-    - selector:
-        matchLabels:
-          os: linux
-          arch: amd64
-      files:
-        - from: "kubectl-sgmap"
-          to: "."
-        - from: "LICENSE"
-          to: "."
-      bin: "./kubectl-sgmap"
-      {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Linux_x86_64.tar.gz" .TagName }}
-    - selector:
-        matchLabels:
-          os: linux
-          arch: arm64
-      files:
-        - from: "kubectl-sgmap"
-          to: "."
-        - from: "LICENSE"
-          to: "."
-      bin: "./kubectl-sgmap"
-      {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Linux_arm64.tar.gz" .TagName }}
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    files:
+      - from: "kubectl-sgmap"
+        to: "."
+      - from: "LICENSE"
+        to: "."
+    {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Darwin_arm64.tar.gz" .TagName }}
+    bin: "./kubectl-sgmap"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    files:
+      - from: "kubectl-sgmap"
+        to: "."
+      - from: "LICENSE"
+        to: "."
+    {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Darwin_x86_64.tar.gz" .TagName }}
+    bin: "./kubectl-sgmap"
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    files:
+      - from: "kubectl-sgmap"
+        to: "."
+      - from: "LICENSE"
+        to: "."
+    {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Linux_x86_64.tar.gz" .TagName }}
+    bin: "./kubectl-sgmap"
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    files:
+      - from: "kubectl-sgmap"
+        to: "."
+      - from: "LICENSE"
+        to: "."
+    {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Linux_arm64.tar.gz" .TagName }}
+    bin: "./kubectl-sgmap"


### PR DESCRIPTION
This pull request makes a minor adjustment to the `.krew.yaml` file, specifically to the plugin installation specification. The change ensures that the `bin` field for the `kubectl-sgmap` binary is correctly set for each platform selector.

* Fixed the placement of the `bin: "./kubectl-sgmap"` field so that it appears after the URI and SHA template for each platform (Darwin arm64, Darwin x86_64, Linux x86_64, Linux arm64), ensuring proper installation configuration. [[1]](diffhunk://#diff-438fccab1284d83ba5971b75756d8cb5e8851e962aa2455476fac7cb7d1e1d85L22-R23) [[2]](diffhunk://#diff-438fccab1284d83ba5971b75756d8cb5e8851e962aa2455476fac7cb7d1e1d85L33-R34) [[3]](diffhunk://#diff-438fccab1284d83ba5971b75756d8cb5e8851e962aa2455476fac7cb7d1e1d85L44-R45) [[4]](diffhunk://#diff-438fccab1284d83ba5971b75756d8cb5e8851e962aa2455476fac7cb7d1e1d85L55-R56)