### PR TITLE
fix: format platform configuration in krew.yaml for better readability

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -10,47 +10,47 @@ spec:
     A kubectl plugin to visualize security group per pod.
     This plugin provides a command to generate a security group map for pods in a Kubernetes cluster.
   platforms:
-  - selector:
-      matchLabels:
-        os: darwin
-        arch: arm64
-    files:
-      - from: "kubectl-sgmap"
-        to: "."
-      - from: "LICENSE"
-        to: "."
-    {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Darwin_arm64.tar.gz" .TagName }}
-    bin: "./kubectl-sgmap"
-  - selector:
-      matchLabels:
-        os: darwin
-        arch: amd64
-    files:
-      - from: "kubectl-sgmap"
-        to: "."
-      - from: "LICENSE"
-        to: "."
-    {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Darwin_x86_64.tar.gz" .TagName }}
-    bin: "./kubectl-sgmap"
-  - selector:
-      matchLabels:
-        os: linux
-        arch: amd64
-    files:
-      - from: "kubectl-sgmap"
-        to: "."
-      - from: "LICENSE"
-        to: "."
-    {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Linux_x86_64.tar.gz" .TagName }}
-    bin: "./kubectl-sgmap"
-  - selector:
-      matchLabels:
-        os: linux
-        arch: arm64
-    files:
-      - from: "kubectl-sgmap"
-        to: "."
-      - from: "LICENSE"
-        to: "."
-    {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Linux_arm64.tar.gz" .TagName }}
-    bin: "./kubectl-sgmap"
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Darwin_arm64.tar.gz" .TagName | indent 6 }}
+      files:
+        - from: "kubectl-sgmap"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: "./kubectl-sgmap"
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Darwin_x86_64.tar.gz" .TagName | indent 6 }}
+      files:
+        - from: "kubectl-sgmap"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: "./kubectl-sgmap"
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Linux_x86_64.tar.gz" .TagName | indent 6 }}
+      files:
+        - from: "kubectl-sgmap"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: "./kubectl-sgmap"
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      {{addURIAndSha "https://github.com/naka-gawa/kubectl-sgmap/releases/download/{{ .TagName }}/kubectl-sgmap_Linux_arm64.tar.gz" .TagName | indent 6 }}
+      files:
+        - from: "kubectl-sgmap"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: "./kubectl-sgmap"


### PR DESCRIPTION
This pull request updates the `.krew.yaml` file to improve the formatting of the `addURIAndSha` function calls for each platform-specific package. The main change is that these calls are now properly indented within their respective sections, which enhances readability and maintains consistency with YAML best practices.

YAML formatting improvements:

* Indented the `addURIAndSha` function calls for each platform and architecture (`Darwin_arm64`, `Darwin_x86_64`, `Linux_x86_64`, `Linux_arm64`) to align them with their corresponding selectors, improving clarity and structure in `.krew.yaml`.